### PR TITLE
Configure the production environment to have web and worker dynos usi…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,9 @@ gem 'strong_migrations', '~> 2.0'
 # Provides authentication solutions for Rails applications
 gem 'devise', '~> 4.9', '>= 4.9.4'
 
+# Process manager for applications with multiple components
+gem 'foreman', '~> 0.88.1'
+
 group :development, :test do
   # Gem to generate valid CPF and CNPJ for testing purposes
   gem 'cpf_cnpj', '~> 0.5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,7 @@ GEM
       railties (>= 5.0.0)
     faker (3.4.2)
       i18n (>= 1.8.11, < 2)
+    foreman (0.88.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.5)
@@ -355,6 +356,7 @@ DEPENDENCIES
   devise (~> 4.9, >= 4.9.4)
   factory_bot_rails (~> 6.4, >= 6.4.3)
   faker (~> 3.4, >= 3.4.2)
+  foreman (~> 0.88.1)
   importmap-rails
   jbuilder
   pg (~> 1.1)

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bundle exec puma -C config/puma.rb
+worker: bundle exec sidekiq -C config/sidekiq.yml

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,21 +1,22 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  user: postgres
-  password: postgres
-  host: localhost
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 development:
   <<: *default
   database: desafio_maino_development
+  user: postgres
+  password: postgres
+  host: localhost
 
 test:
   <<: *default
   database: desafio_maino_test
+  user: postgres
+  password: postgres
+  host: localhost
 
 production:
   <<: *default
-  database: desafio_maino_production
-  username: desafio_maino
-  password: <%= ENV["DESAFIO_MAINO_DATABASE_PASSWORD"] %>
+  url: <%= ENV["DATABASE_URL"] %>

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+SIDEKIQ_REDIS_CONFIGURATION = {
+  url: ENV.fetch('REDIS_URL', 'redis://localhost:6379'),
+  ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
+}.freeze
+
+Sidekiq.configure_server do |config|
+  config.redis = SIDEKIQ_REDIS_CONFIGURATION
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = SIDEKIQ_REDIS_CONFIGURATION
+end


### PR DESCRIPTION
## Problem / Motivation

We need to configure the production environment to use web and worker dynos. Also, we need to configure the `database.yml` to use the Heroku Postgres database URL environment variable.

## Solution

This PR adds the foreman gem to handle the `Procfile` where we defined the web and worker dynos to be used in production.

We're also using the environment variable `DATABASE_URL` to connect to our Postgres production and Heroku resources.

## Tasks

* [x] Add foreman gem to the `Gemfile`.
* [x] Create a `Procfile` with web and worker definitions.
* [x] Configure the `database.yml` file to use the  Heroku Postgres database URL.

## Tickets

* We don't have tickets.

## Changelog

No changes since this PR has been ready for review.

## Test Plan

No additional test plans are required.